### PR TITLE
Added support for customizing Stripe Checkout parameters

### DIFF
--- a/drf_stripe/settings.py
+++ b/drf_stripe/settings.py
@@ -7,7 +7,11 @@ DEFAULTS = {
     "STRIPE_API_SECRET": "my_stripe_api_key",
     "STRIPE_WEBHOOK_SECRET": "my_stripe_webhook_key",
     "FRONT_END_BASE_URL": "http://localhost:3000",
-    "NEW_USER_FREE_TRIAL_DAYS": 15
+    "NEW_USER_FREE_TRIAL_DAYS": 15,
+    "CHECKOUT_SUCCESS_URL_PATH": "payment",
+    "CHECKOUT_CANCEL_URL_PATH": "manage-subscription",
+    "DEFAULT_PAYMENT_METHOD_TYPES": ["card"],
+    "DEFAULT_CHECKOUT_MODE": "subscription"
 }
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = drf-stripe-subscription
-version = 1.1.7
+version = 1.1.8
 description = A Django app that provides subscription features with Stripe and REST endpoints.
 long_description = file: README.md
 url = https://github.com/oscarychen/drf-stripe-subscription


### PR DESCRIPTION
This addresses issue #2.

Some of the checkout parameters are specified in `DRF_STRIPE` settings:

`CHECKOUT_SUCCESS_URL_PATH`: The checkout session success redirect url path.
`CHECKOUT_CANCEL_URL_PATH`: The checkout session cancel redirect url path.
`PAYMENT_METHOD_TYPES`: The default
default [payment method types](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types)
, defaults to `["card"]`.
`DEFAULT_CHECKOUT_MODE`: The default checkout mode, defaults to `"subscription"`.

By default, you can create a checkout session by calling the default REST endpoint `my-site.com/stripe/checkout/`, this
REST endpoint utilizes `drf_stripe.serializers.CheckoutRequestSerializer` to validate checkout parameters and create a
Stripe Checkout Session. Only a `price_id` is needed, `quantity` defaults to 1.

You can extend this serializer and customize Checkout behavior, such as specifying multiple `line_items`
, `payment_method_types`, and `checkout_mode`.

See README for more info.