### PR TITLE
FIX: Validation issue when next_invoice_sequence is omitted from API response

### DIFF
--- a/drf_stripe/stripe_models/customer.py
+++ b/drf_stripe/stripe_models/customer.py
@@ -26,7 +26,7 @@ class StripeCustomer(BaseModel):
     invoice_prefix: Optional[str]
     invoice_settings: Optional[Dict]
     livemode: Optional[bool]
-    next_invoice_sequence: Optional[int]
+    next_invoice_sequence: Optional[int] = None
     preferred_locales: Optional[List[str]]
     sources: Optional[List[Dict]] = None
     subscriptions: Optional[List[StripeSubscriptionItems]] = None


### PR DESCRIPTION
This fixes a validation issue when `next_invoice_sequence` is omitted from the API response, which I ran into and can happen according to the documentation:

https://docs.stripe.com/api/customers/object#customer_object-next_invoice_sequence

> The suffix of the customer’s next invoice number (for example, 0001). When the account uses account level sequencing, this parameter is ignored in API requests and **the field omitted in API responses.**

The API response that failed before this fix and worked after this fix:

```
{
  "data": [
    {
      "address": null,
      "balance": 0,
      "created": <timestamp>,
      "currency": "usd",
      "default_currency": "usd",
      "default_source": null,
      "delinquent": false,
      "description": null,
      "discount": null,
      "email": "<email>",
      "id": "<id>",
      "invoice_prefix": "<prefix>",
      "invoice_settings": {
        "custom_fields": null,
        "default_payment_method": null,
        "footer": null,
        "rendering_options": null
      },
      "livemode": false,
      "metadata": {},
      "name": null,
      "object": "customer",
      "phone": null,
      "preferred_locales": [],
      "shipping": null,
      "tax_exempt": "none",
      "test_clock": null
    }
  ],
  "has_more": false,
  "object": "list",
  "url": "/v1/customers"
}
```

Before:
```
pydantic_core._pydantic_core.ValidationError: 1 validation error for StripeCustomers
data.0.next_invoice_sequence
  Field required [type=missing, input_value=<Customer customer id=cus...,
  "test_clock": null
}, input_type=Customer]
    For further information visit https://errors.pydantic.dev/2.8/v/missing
```

After:
```
Created 1 new Subscriptions.
```