### PR TITLE
BillingAccount feature and others

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,8 +328,6 @@ Key points
 - By default DRF_STRIPE['BILLING_ACCOUNT_MODEL'] is None and the package behaves exactly as before (legacy per-user).
 - To enable billing-account flows, implement a concrete BillingAccount in your project (extend AbstractBillingAccount),
   and configure DRF_STRIPE['BILLING_ACCOUNT_MODEL'] to point to it (e.g. "myapp.OrganizationBillingAccount").
-- Subscription quantity (seats): By default, the package uses DRF_STRIPE['DEFAULT_SUBSCRIPTION_QUANTITY'] (defaults to 1).
-  If you need per-account seat control, add a 'seats' field to your concrete billing account model.
 
 How to opt-in (recommended pattern)
 1) Implement your BillingAccount in your app, extending the abstract base:
@@ -345,24 +343,12 @@ class OrganizationBillingAccount(AbstractBillingAccount):
         return self.organization
 ```
 
-If you need per-account seat management, add a `seats` field:
-
-```python
-class OrganizationBillingAccount(AbstractBillingAccount):
-    organization = models.OneToOneField("myapp.Organization", on_delete=models.CASCADE, related_name="billing_account")
-    seats = models.PositiveIntegerField(default=1)  # Optional: control seats per billing account
-
-    def get_owner(self):
-        return self.organization
-```
-
 2) Configure in settings.py:
 
 ```python
 DRF_STRIPE = {
     # ... other settings ...
     "BILLING_ACCOUNT_MODEL": "myapp.OrganizationBillingAccount",
-    "DEFAULT_SUBSCRIPTION_QUANTITY": 1,  # Optional: set global default for subscription quantity
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,8 @@ Some of the checkout parameters are specified in `DRF_STRIPE` settings:
 
 `CHECKOUT_CANCEL_URL_PATH`: The checkout session cancel redirect url path.
 
+`CUSTOMER_PORTAL_RETURN_URL_PATH`: The customer portal session return url path, defaults to `"manage-subscription"`.
+
 `PAYMENT_METHOD_TYPES`: The default [payment method types](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types)
 , defaults to `["card"]`.
 

--- a/drf_stripe/management/commands/migrate_legacy_billing.py
+++ b/drf_stripe/management/commands/migrate_legacy_billing.py
@@ -1,0 +1,51 @@
+from django.core.management.base import BaseCommand
+from django.apps import apps as django_apps
+from django.contrib.contenttypes.models import ContentType
+from drf_stripe.models import StripeUser, Subscription
+from drf_stripe.settings import drf_stripe_settings
+
+
+class Command(BaseCommand):
+    """Create BillingAccount entries for existing StripeUser records and attach existing Subscriptions. Only runs if BILLING_ACCOUNT_MODEL is configured."""
+    help = "Create BillingAccount entries for existing StripeUser records and attach existing Subscriptions. Only runs if BILLING_ACCOUNT_MODEL is configured."
+
+    def handle(self, *args, **options):
+        BillingModelPath = drf_stripe_settings.BILLING_ACCOUNT_MODEL
+        if not BillingModelPath:
+            self.stdout.write(self.style.WARNING("DRF_STRIPE.BILLING_ACCOUNT_MODEL not configured. Nothing to migrate."))
+            return
+        try:
+            app_label, model_name = BillingModelPath.split('.', 1)
+            BillingModel = django_apps.get_model(app_label, model_name)
+        except Exception as e:
+            self.stdout.write(self.style.ERROR(f"Cannot resolve BillingModel '{BillingModelPath}': {e}"))
+            return
+
+        users = StripeUser.objects.all()
+        for su in users:
+            user = su.user
+            try:
+                ct = ContentType.objects.get_for_model(user.__class__)
+                # If BillingModel uses Generic relation (most common when based on AbstractBillingAccount),
+                # create using content_type/object_id
+                billing_account, created = BillingModel.objects.get_or_create(
+                    content_type=ct,
+                    object_id=user.pk,
+                    defaults={"stripe_customer_id": su.customer_id}
+                )
+                if created:
+                    self.stdout.write(self.style.SUCCESS(f"Created BillingAccount {billing_account.pk} for user {user.pk}"))
+                else:
+                    self.stdout.write(f"Existing BillingAccount {billing_account.pk} for user {user.pk}")
+
+                # Move subscriptions that link to stripe_user to use billing account's generic reference fields if applicable
+                for sub in Subscription.objects.filter(stripe_user=su):
+                    if hasattr(BillingModel, 'content_type'):
+                        sub.billing_account_content_type = ContentType.objects.get_for_model(BillingModel)
+                        sub.billing_account_object_id = billing_account.pk
+                        sub.save(update_fields=["billing_account_content_type", "billing_account_object_id"])
+                        self.stdout.write(f"Moved Subscription {sub.subscription_id} to BillingAccount {billing_account.pk}")
+                    else:
+                        self.stdout.write(self.style.WARNING(f"BillingModel {BillingModelPath} does not use content_type/object_id; manual migration required for subscription {sub.subscription_id}"))
+            except Exception as e:
+                self.stdout.write(self.style.ERROR(f"Failed migrating user {user.pk}: {e}"))

--- a/drf_stripe/models.py
+++ b/drf_stripe/models.py
@@ -27,7 +27,7 @@ def get_drf_stripe_user_model():
 class StripeUser(models.Model):
     """Link between a Django user and a Stripe Customer (legacy per-user flow)."""
     user = models.OneToOneField(
-        drf_stripe_settings.DJANGO_USER_MODEL or settings.AUTH_USER_MODEL,
+        get_drf_stripe_user_model_name(),
         on_delete=models.CASCADE,
         related_name='stripe_user',
         primary_key=True
@@ -104,7 +104,7 @@ class AbstractBillingAccount(models.Model):
     stripe_subscription_id = models.CharField(max_length=256, null=True, blank=True)
     seats = models.PositiveIntegerField(default=1)
     manager_user = models.ForeignKey(
-        drf_stripe_settings.DJANGO_USER_MODEL or settings.AUTH_USER_MODEL,
+        get_drf_stripe_user_model_name(),
         null=True,
         blank=True,
         on_delete=models.SET_NULL,

--- a/drf_stripe/models.py
+++ b/drf_stripe/models.py
@@ -99,10 +99,14 @@ class Price(models.Model):
 
 
 class AbstractBillingAccount(models.Model):
-    """Abstract billing account to extend in the project for multi-user/group billing flows."""
+    """Abstract billing account to extend in the project for multi-user/group billing flows.
+    
+    Note: The 'seats' field has been removed from this abstract model. If you need per-account
+    seat control, add a 'seats' field to your concrete billing account model. Otherwise, the
+    DRF_STRIPE['DEFAULT_SUBSCRIPTION_QUANTITY'] setting will be used for subscription quantities.
+    """
     stripe_customer_id = models.CharField(max_length=256, null=True, blank=True)
     stripe_subscription_id = models.CharField(max_length=256, null=True, blank=True)
-    seats = models.PositiveIntegerField(default=1)
     manager_user = models.ForeignKey(
         get_drf_stripe_user_model_name(),
         null=True,

--- a/drf_stripe/models.py
+++ b/drf_stripe/models.py
@@ -6,6 +6,9 @@ from django.conf import settings
 from .stripe_models.subscription import ACCESS_GRANTING_STATUSES
 from .settings import drf_stripe_settings
 
+from django.contrib.contenttypes.fields import GenericForeignKey
+from django.contrib.contenttypes.models import ContentType
+
 
 def get_drf_stripe_user_model_name():
     if drf_stripe_settings.DJANGO_USER_MODEL:
@@ -22,34 +25,31 @@ def get_drf_stripe_user_model():
 
 
 class StripeUser(models.Model):
-    """A model linking Django user model with a Stripe User"""
-    user = models.OneToOneField(get_drf_stripe_user_model(), on_delete=models.CASCADE, related_name='stripe_user',
-                                primary_key=True)
+    """Link between a Django user and a Stripe Customer (legacy per-user flow)."""
+    user = models.OneToOneField(get_drf_stripe_user_model(), on_delete=models.CASCADE, related_name='stripe_user', primary_key=True)
     customer_id = models.CharField(max_length=128, null=True)
 
     @property
     def subscription_items(self):
-        """Returns a set of SubscriptionItem instances associated with the StripeUser"""
+        """Subscription items associated with this StripeUser."""
         return SubscriptionItem.objects.filter(subscription__stripe_user=self)
 
     @property
     def current_subscription_items(self):
-        """Returns a set of SubscriptionItem instances that grants current access."""
+        """Subscription items that currently grant access."""
         return self.subscription_items.filter(subscription__status__in=ACCESS_GRANTING_STATUSES)
 
     @property
     def subscribed_products(self):
-        """Returns a set of Product instances the StripeUser currently has"""
-        return {item.price.product for item in
-                self.current_subscription_items.prefetch_related("price", "price__product")}
+        """Products the StripeUser currently has access to."""
+        return {item.price.product for item in self.current_subscription_items.prefetch_related("price", "price__product")}
 
     @property
     def subscribed_features(self):
-        """Returns a set of Feature instances the StripeUser has access to."""
+        """Features the StripeUser currently has access to."""
         price_list = self.current_subscription_items.values_list('price', flat=True)
         product_list = Price.objects.filter(pk__in=price_list).values_list("product", flat=True)
-        return {item.feature for item in
-                ProductFeature.objects.filter(product_id__in=product_list).prefetch_related("feature")}
+        return {item.feature for item in ProductFeature.objects.filter(product_id__in=product_list).prefetch_related("feature")}
 
     class Meta:
         indexes = [
@@ -58,17 +58,13 @@ class StripeUser(models.Model):
 
 
 class Feature(models.Model):
-    """
-    A model used to keep track of features provided by your application.
-    This does not correspond to a Stripe object, but the feature ids should be listed as
-     a space delimited strings in Stripe.product.metadata.features
-    """
+    """Application-level feature representation tied to Stripe product metadata."""
     feature_id = models.CharField(max_length=64, primary_key=True)
     description = models.CharField(max_length=256, null=True, blank=True)
 
 
 class Product(models.Model):
-    """A model representing a Stripe Product"""
+    """Stripe Product representation cached locally."""
     product_id = models.CharField(max_length=256, primary_key=True)
     active = models.BooleanField()
     description = models.CharField(max_length=1024, null=True, blank=True)
@@ -76,18 +72,17 @@ class Product(models.Model):
 
 
 class ProductFeature(models.Model):
-    """A model representing association of Product and Feature instances. They have many-to-many relationship."""
+    """Association between Product and Feature."""
     product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name="linked_features")
     feature = models.ForeignKey(Feature, on_delete=models.CASCADE, related_name="linked_products")
 
 
 class Price(models.Model):
-    """A model representing to a Stripe Price object, with enhanced attributes."""
+    """Stripe Price representation with extras for app logic."""
     price_id = models.CharField(max_length=256, primary_key=True)
     product = models.ForeignKey(Product, on_delete=models.CASCADE, related_name="prices")
-    nickname = models.CharField(max_length=256, null=True, blank=True)  # displayed name
-    price = models.PositiveIntegerField()  # price in cents, corresponding to Stripe unit_amount
-    # billing frequency, translated from Stripe price.recurring.interval and price.recurring.interval_count
+    nickname = models.CharField(max_length=256, null=True, blank=True)
+    price = models.PositiveIntegerField()
     freq = models.CharField(max_length=64, null=True, blank=True)
     active = models.BooleanField()
     currency = models.CharField(max_length=3)
@@ -98,16 +93,48 @@ class Price(models.Model):
         ]
 
 
+class AbstractBillingAccount(models.Model):
+    """Abstract billing account to extend in the project for multi-user/group billing flows."""
+    stripe_customer_id = models.CharField(max_length=256, null=True, blank=True)
+    stripe_subscription_id = models.CharField(max_length=256, null=True, blank=True)
+    seats = models.PositiveIntegerField(default=1)
+    manager_user = models.ForeignKey(get_drf_stripe_user_model(), null=True, blank=True, on_delete=models.SET_NULL, related_name="+")
+
+    class Meta:
+        abstract = True
+
+    def has_active_subscription(self):
+        """Return True when this billing account currently has a subscription id recorded."""
+        return bool(self.stripe_subscription_id)
+
+    def get_or_create_stripe_customer(self, stripe_module, **kwargs):
+        """Create or return the Stripe customer id for this billing account. Projects may override."""
+        if self.stripe_customer_id:
+            return self.stripe_customer_id
+        metadata = kwargs.pop("metadata", {}) or {}
+        customer = stripe_module.Customer.create(metadata=metadata, **kwargs)
+        self.stripe_customer_id = customer["id"]
+        self.save(update_fields=["stripe_customer_id"])
+        return self.stripe_customer_id
+
+    def can_manage_billing(self, user):
+        """Return True if the provided user is allowed to perform payment actions for this account."""
+        if self.manager_user is None:
+            return False
+        return user.pk == getattr(self.manager_user, 'pk', None)
+
+
 class Subscription(models.Model):
-    """
-    A model representing Subscription, corresponding to a Stripe Subscription object.
-    """
+    """Subscription corresponding to a Stripe Subscription. Supports legacy per-user and optional billing owner."""
     subscription_id = models.CharField(max_length=256, primary_key=True)
-    stripe_user = models.ForeignKey(StripeUser, on_delete=models.CASCADE, related_name="subscriptions")
+    stripe_user = models.ForeignKey(StripeUser, on_delete=models.CASCADE, related_name="subscriptions", null=True, blank=True)
+    billing_account_content_type = models.ForeignKey(ContentType, null=True, blank=True, on_delete=models.CASCADE, related_name='+')
+    billing_account_object_id = models.PositiveIntegerField(null=True, blank=True)
+
     period_start = models.DateTimeField(null=True, blank=True)
     period_end = models.DateTimeField(null=True, blank=True)
     cancel_at = models.DateTimeField(null=True, blank=True)
-    cancel_at_period_end = models.BooleanField()
+    cancel_at_period_end = models.BooleanField(default=False)
     ended_at = models.DateTimeField(null=True, blank=True)
     status = models.CharField(max_length=64)
     trial_end = models.DateTimeField(null=True, blank=True)
@@ -115,14 +142,28 @@ class Subscription(models.Model):
 
     class Meta:
         indexes = [
-            models.Index(fields=['stripe_user', 'status'])
+            models.Index(fields=['stripe_user', 'status']),
+            models.Index(fields=['billing_account_content_type', 'billing_account_object_id', 'status'])
         ]
+
+    @property
+    def billing_account(self):
+        """Return the billing account object linked to this subscription, if any."""
+        if self.billing_account_content_type_id and self.billing_account_object_id:
+            return self.billing_account_content_type.get_object_for_this_type(pk=self.billing_account_object_id)
+        return None
+
+    def get_owner(self):
+        """Return the owning object: billing account if present, else the legacy user."""
+        if self.billing_account:
+            return self.billing_account
+        if self.stripe_user:
+            return self.stripe_user.user
+        return None
 
 
 class SubscriptionItem(models.Model):
-    """
-    A model representing relation of Price and Subscription, corresponding to Stripe Subscription line item.
-    """
+    """Relation between Subscription and Price representing a subscription line item."""
     sub_item_id = models.CharField(max_length=256, primary_key=True)
     subscription = models.ForeignKey(Subscription, on_delete=models.CASCADE, related_name="items")
     price = models.ForeignKey(Price, on_delete=models.CASCADE, related_name="+")

--- a/drf_stripe/models.py
+++ b/drf_stripe/models.py
@@ -26,7 +26,12 @@ def get_drf_stripe_user_model():
 
 class StripeUser(models.Model):
     """Link between a Django user and a Stripe Customer (legacy per-user flow)."""
-    user = models.OneToOneField(get_drf_stripe_user_model(), on_delete=models.CASCADE, related_name='stripe_user', primary_key=True)
+    user = models.OneToOneField(
+        drf_stripe_settings.DJANGO_USER_MODEL or settings.AUTH_USER_MODEL,
+        on_delete=models.CASCADE,
+        related_name='stripe_user',
+        primary_key=True
+    )
     customer_id = models.CharField(max_length=128, null=True)
 
     @property
@@ -98,7 +103,13 @@ class AbstractBillingAccount(models.Model):
     stripe_customer_id = models.CharField(max_length=256, null=True, blank=True)
     stripe_subscription_id = models.CharField(max_length=256, null=True, blank=True)
     seats = models.PositiveIntegerField(default=1)
-    manager_user = models.ForeignKey(get_drf_stripe_user_model(), null=True, blank=True, on_delete=models.SET_NULL, related_name="+")
+    manager_user = models.ForeignKey(
+        drf_stripe_settings.DJANGO_USER_MODEL or settings.AUTH_USER_MODEL,
+        null=True,
+        blank=True,
+        on_delete=models.SET_NULL,
+        related_name="+"
+    )
 
     class Meta:
         abstract = True

--- a/drf_stripe/models.py
+++ b/drf_stripe/models.py
@@ -99,12 +99,7 @@ class Price(models.Model):
 
 
 class AbstractBillingAccount(models.Model):
-    """Abstract billing account to extend in the project for multi-user/group billing flows.
-    
-    Note: The 'seats' field has been removed from this abstract model. If you need per-account
-    seat control, add a 'seats' field to your concrete billing account model. Otherwise, the
-    DRF_STRIPE['DEFAULT_SUBSCRIPTION_QUANTITY'] setting will be used for subscription quantities.
-    """
+    """Abstract billing account to extend in the project for multi-user/group billing flows."""
     stripe_customer_id = models.CharField(max_length=256, null=True, blank=True)
     stripe_subscription_id = models.CharField(max_length=256, null=True, blank=True)
     manager_user = models.ForeignKey(

--- a/drf_stripe/serializers.py
+++ b/drf_stripe/serializers.py
@@ -193,7 +193,7 @@ class CheckoutRequestSerializer(serializers.Serializer):
                 checkout_session = stripe_module.checkout.Session.create(
                     payment_method_types=drf_stripe_settings.DEFAULT_PAYMENT_METHOD_TYPES,
                     mode=drf_stripe_settings.DEFAULT_CHECKOUT_MODE,
-                    line_items=[{"price": price_id, "quantity": getattr(billing_account_instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)}],
+                    line_items=[{"price": price_id, "quantity": getattr(billing_account_instance, "seats", drf_stripe_settings.DEFAULT_MAX_SUBSCRIPTION_QUANTITY)}],
                     customer=customer_id,
                     success_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CHECKOUT_SUCCESS_URL_PATH}",
                     cancel_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CHECKOUT_CANCEL_URL_PATH}",

--- a/drf_stripe/serializers.py
+++ b/drf_stripe/serializers.py
@@ -193,7 +193,7 @@ class CheckoutRequestSerializer(serializers.Serializer):
                 checkout_session = stripe_module.checkout.Session.create(
                     payment_method_types=drf_stripe_settings.DEFAULT_PAYMENT_METHOD_TYPES,
                     mode=drf_stripe_settings.DEFAULT_CHECKOUT_MODE,
-                    line_items=[{"price": price_id, "quantity": getattr(billing_account_instance, "seats", 1)}],
+                    line_items=[{"price": price_id, "quantity": getattr(billing_account_instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)}],
                     customer=customer_id,
                     success_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CHECKOUT_SUCCESS_URL_PATH}",
                     cancel_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CHECKOUT_CANCEL_URL_PATH}",

--- a/drf_stripe/serializers.py
+++ b/drf_stripe/serializers.py
@@ -2,9 +2,13 @@ from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from stripe.error import StripeError
 
-from drf_stripe.models import SubscriptionItem, Product, Price, Subscription
+from drf_stripe.models import SubscriptionItem, Product, Price, Subscription, StripeUser
 from drf_stripe.stripe_api.checkout import stripe_api_create_checkout_session
 from drf_stripe.stripe_api.customers import get_or_create_stripe_user
+from drf_stripe.settings import drf_stripe_settings
+
+from django.apps import apps as django_apps
+from django.contrib.contenttypes.models import ContentType
 
 
 class SubscriptionSerializer(serializers.ModelSerializer):
@@ -79,18 +83,128 @@ class CheckoutRequestSerializer(serializers.Serializer):
     """Handles request data to create a Stripe checkout session."""
     price_id = serializers.CharField()
     owner = serializers.HiddenField(default=serializers.CurrentUserDefault())
+    owner_type = serializers.CharField(required=False, allow_null=True)  # e.g. 'app_label.ModelName' or 'modelname'
+    owner_id = serializers.CharField(required=False, allow_null=True)
 
     def validate(self, attrs):
-        stripe_user = get_or_create_stripe_user(user_id=self.context['request'].user.id)
+        request = self.context['request']
+        price_id = attrs['price_id']
+
+        # set stripe api key
+        stripe_module = __import__('stripe')
+        stripe_module.api_key = drf_stripe_settings.STRIPE_API_SECRET
+
+        # If billing model is not configured, keep legacy per-user flow (StripeUser)
+        billing_model_path = drf_stripe_settings.BILLING_ACCOUNT_MODEL
+        BillingModel = None
+        if billing_model_path:
+            try:
+                app_label, model_name = billing_model_path.split('.', 1)
+                BillingModel = django_apps.get_model(app_label, model_name)
+            except Exception:
+                # allow full label as fallback
+                try:
+                    BillingModel = django_apps.get_model(billing_model_path)
+                except Exception:
+                    BillingModel = None
+
+        # Determine customer: either BillingModel (if configured) or legacy StripeUser
+        customer_id = None
+        billing_account_instance = None
+
+        if BillingModel:
+            # Use provided owner_type/owner_id if given, else default to current user owner
+            owner_type = attrs.get('owner_type')
+            owner_id = attrs.get('owner_id')
+            try:
+                if owner_type and owner_id:
+                    # owner_type may be 'app_label.ModelName' or 'modelname'
+                    if '.' in owner_type:
+                        owner_app_label, owner_model = owner_type.split('.', 1)
+                        owner_cls = django_apps.get_model(owner_app_label, owner_model)
+                    else:
+                        owner_cls = None
+                        for app_config in django_apps.get_app_configs():
+                            try:
+                                owner_cls = django_apps.get_model(app_config.label, owner_type)
+                                break
+                            except Exception:
+                                continue
+                    if owner_cls is None:
+                        raise ValidationError(f"Unknown owner_type {owner_type}")
+                    owner_obj = owner_cls.objects.get(pk=owner_id)
+                else:
+                    # default: assume billing model keyed by request.user
+                    owner_obj = request.user
+
+                # Attempt to find or create a BillingModel instance.
+                billing_account_instance = None
+                # Pattern 1: BillingModel uses Generic relation content_type/object_id
+                if hasattr(BillingModel, 'content_type'):
+                    ct = ContentType.objects.get_for_model(owner_obj.__class__)
+                    billing_account_instance, _ = BillingModel.objects.get_or_create(content_type=ct, object_id=owner_obj.pk)
+                else:
+                    # Pattern 2: BillingModel has an FK field to the owner with common names
+                    for field_name in ('owner', 'user', 'organization', 'team'):
+                        if field_name in [f.name for f in BillingModel._meta.get_fields()]:
+                            kwargs = {field_name: owner_obj}
+                            billing_account_instance, _ = BillingModel.objects.get_or_create(**kwargs)
+                            break
+                    if billing_account_instance is None:
+                        # Last resort try get_or_create by pk if possible
+                        try:
+                            billing_account_instance, _ = BillingModel.objects.get_or_create(pk=getattr(owner_obj, 'pk', None))
+                        except Exception:
+                            raise ValidationError("Cannot create or resolve billing account for given owner")
+
+                # Authorization: ensure request.user can perform payment if they attempt to create/manage checkout for an owner
+                if hasattr(billing_account_instance, 'can_manage_billing'):
+                    if not billing_account_instance.can_manage_billing(request.user):
+                        raise ValidationError("User is not authorized to manage billing for this account.")
+
+                # Create/get stripe customer
+                try:
+                    customer_id = billing_account_instance.get_or_create_stripe_customer(
+                        stripe_module,
+                        email=getattr(request.user, drf_stripe_settings.DJANGO_USER_EMAIL_FIELD, None),
+                        metadata={"owner_type": getattr(owner_obj.__class__, '__name__', ''), "owner_id": str(getattr(owner_obj, 'pk', ''))}
+                    )
+                except TypeError:
+                    customer_id = billing_account_instance.get_or_create_stripe_customer(stripe_module)
+            except ValidationError:
+                raise
+            except Exception as e:
+                raise ValidationError(f"Failed to resolve billing account: {e}")
+
+        else:
+            # Legacy per-user flow using package helper
+            try:
+                stripe_user = get_or_create_stripe_user(user_id=request.user.id)
+                customer_id = stripe_user.customer_id
+            except Exception as e:
+                raise ValidationError(f"Failed to resolve legacy Stripe user: {e}")
+
+        # Create checkout session using customer_id (prefer package helper)
         try:
-            checkout_session = stripe_api_create_checkout_session(
-                customer_id=stripe_user.customer_id,
-                price_id=attrs['price_id'],
-                trial_end='auto' if stripe_user.subscription_items.count() == 0 else None
-            )
+            try:
+                checkout_session = stripe_api_create_checkout_session(customer_id=customer_id, price_id=price_id)
+            except TypeError:
+                # fallback direct call
+                checkout_session = stripe_module.checkout.Session.create(
+                    payment_method_types=drf_stripe_settings.DEFAULT_PAYMENT_METHOD_TYPES,
+                    mode=drf_stripe_settings.DEFAULT_CHECKOUT_MODE,
+                    line_items=[{"price": price_id, "quantity": getattr(billing_account_instance, "seats", 1)}],
+                    customer=customer_id,
+                    success_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CHECKOUT_SUCCESS_URL_PATH}",
+                    cancel_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CHECKOUT_CANCEL_URL_PATH}",
+                    metadata={"owner_type": getattr(billing_account_instance.__class__, '__name__', '') if billing_account_instance else 'user', "owner_id": str(getattr(billing_account_instance, 'pk', getattr(request.user, 'pk', '')))}
+                )
             attrs['session_id'] = checkout_session['id']
         except StripeError as e:
             raise ValidationError(e.error)
+        except Exception as e:
+            raise ValidationError(str(e))
+
         return attrs
 
     def update(self, instance, validated_data):

--- a/drf_stripe/settings.py
+++ b/drf_stripe/settings.py
@@ -23,6 +23,10 @@ DEFAULTS = {
     # If None, billing-account flows are disabled and legacy per-user behaviour is used.
     # Example: "myapp.OrganizationBillingAccount"
     "BILLING_ACCOUNT_MODEL": None,
+    # Default quantity for subscription line items when using billing accounts.
+    # This is used when the billing account instance doesn't have a 'seats' attribute.
+    # Can be overridden by adding a 'seats' field to your custom billing account model.
+    "DEFAULT_SUBSCRIPTION_QUANTITY": 1,
 }
 
 

--- a/drf_stripe/settings.py
+++ b/drf_stripe/settings.py
@@ -18,7 +18,11 @@ DEFAULTS = {
     "DJANGO_USER_EMAIL_FIELD": "email",  # used to match Stripe customer email
     "USER_CREATE_DEFAULTS_ATTRIBUTE_MAP": {  # attributes to copy from Stripe customer when creating new Django user
         "username": "email"
-    }
+    },
+    # Optional path to a BillingAccount model in your project.
+    # If None, billing-account flows are disabled and legacy per-user behaviour is used.
+    # Example: "myapp.OrganizationBillingAccount"
+    "BILLING_ACCOUNT_MODEL": None,
 }
 
 
@@ -35,7 +39,6 @@ class DrfStripeSettings:
         return self._user_settings
 
     def __getattr__(self, attr):
-
         # check the setting is accepted
         if attr not in self.defaults:
             raise AttributeError(f"Invalid DRF_STRIPE setting: {attr}")

--- a/drf_stripe/settings.py
+++ b/drf_stripe/settings.py
@@ -24,7 +24,7 @@ DEFAULTS = {
     # Example: "myapp.OrganizationBillingAccount"
     "BILLING_ACCOUNT_MODEL": None,
     # Default quantity for subscription line items.
-    "DEFAULT_SUBSCRIPTION_QUANTITY": 1,
+    "DEFAULT_MAX_SUBSCRIPTION_QUANTITY": 1,
 }
 
 

--- a/drf_stripe/settings.py
+++ b/drf_stripe/settings.py
@@ -23,9 +23,7 @@ DEFAULTS = {
     # If None, billing-account flows are disabled and legacy per-user behaviour is used.
     # Example: "myapp.OrganizationBillingAccount"
     "BILLING_ACCOUNT_MODEL": None,
-    # Default quantity for subscription line items when using billing accounts.
-    # This is used when the billing account instance doesn't have a 'seats' attribute.
-    # Can be overridden by adding a 'seats' field to your custom billing account model.
+    # Default quantity for subscription line items.
     "DEFAULT_SUBSCRIPTION_QUANTITY": 1,
 }
 

--- a/drf_stripe/settings.py
+++ b/drf_stripe/settings.py
@@ -10,6 +10,7 @@ DEFAULTS = {
     "NEW_USER_FREE_TRIAL_DAYS": None,
     "CHECKOUT_SUCCESS_URL_PATH": "payment",
     "CHECKOUT_CANCEL_URL_PATH": "manage-subscription",
+    "CUSTOMER_PORTAL_RETURN_URL_PATH": "manage-subscription",
     "DEFAULT_PAYMENT_METHOD_TYPES": ["card"],
     "DEFAULT_CHECKOUT_MODE": "subscription",
     "DEFAULT_DISCOUNTS": None,

--- a/drf_stripe/stripe_api/customer_portal.py
+++ b/drf_stripe/stripe_api/customer_portal.py
@@ -13,7 +13,7 @@ def stripe_api_create_billing_portal_session(user_id):
 
     session = stripe.billing_portal.Session.create(
         customer=stripe_user.customer_id,
-        return_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/manage-subscription/"
+        return_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CUSTOMER_PORTAL_RETURN_URL_PATH}/"
     )
 
     return session

--- a/drf_stripe/stripe_api/customer_portal.py
+++ b/drf_stripe/stripe_api/customer_portal.py
@@ -13,7 +13,7 @@ def stripe_api_create_billing_portal_session(user_id):
 
     session = stripe.billing_portal.Session.create(
         customer=stripe_user.customer_id,
-        return_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CUSTOMER_PORTAL_RETURN_URL_PATH}/"
+        return_url=f"{drf_stripe_settings.FRONT_END_BASE_URL}/{drf_stripe_settings.CUSTOMER_PORTAL_RETURN_URL_PATH}"
     )
 
     return session

--- a/drf_stripe/stripe_api/customers.py
+++ b/drf_stripe/stripe_api/customers.py
@@ -264,8 +264,10 @@ def _get_or_create_stripe_user_from_user_id_email(user_id, user_email: str, cust
 
     :param user_id: user id
     :param str user_email: user email address
+    :param str customer_id: Stripe customer id (optional)
     """
-    stripe_user, created = StripeUser.objects.get_or_create(user_id=user_id, customer_id=customer_id)
+    defaults = {'customer_id': customer_id} if customer_id else {}
+    stripe_user, created = StripeUser.objects.get_or_create(user_id=user_id, defaults=defaults)
 
     if created and not customer_id:
         customer = _stripe_api_get_or_create_customer_from_email(user_email)

--- a/drf_stripe/stripe_webhooks/billing.py
+++ b/drf_stripe/stripe_webhooks/billing.py
@@ -1,0 +1,99 @@
+import stripe
+from django.conf import settings
+from django.http import HttpResponse
+from django.views.decorators.csrf import csrf_exempt
+from django.apps import apps as django_apps
+from django.contrib.contenttypes.models import ContentType
+from drf_stripe.settings import drf_stripe_settings
+
+stripe.api_key = settings.STRIPE_SECRET_KEY
+ENDPOINT_SECRET = settings.STRIPE_WEBHOOK_SECRET
+
+
+@csrf_exempt
+def stripe_webhook(request):
+    payload = request.body
+    sig_header = request.META.get("HTTP_STRIPE_SIGNATURE", "")
+    try:
+        event = stripe.Webhook.construct_event(payload, sig_header, ENDPOINT_SECRET)
+    except Exception:
+        return HttpResponse(status=400)
+
+    typ = event['type']
+    obj = event['data'].get('object') or {}
+
+    # Only attempt billing-account mapping if user enabled BILLING_ACCOUNT_MODEL
+    BillingModelPath = drf_stripe_settings.BILLING_ACCOUNT_MODEL
+    BillingModel = None
+    if BillingModelPath:
+        try:
+            app_label, model_name = BillingModelPath.split('.', 1)
+            BillingModel = django_apps.get_model(app_label, model_name)
+        except Exception:
+            try:
+                BillingModel = django_apps.get_model(BillingModelPath)
+            except Exception:
+                BillingModel = None
+
+    # events that may carry subscription id
+    if typ in ("checkout.session.completed", "invoice.payment_succeeded", "customer.subscription.created", "customer.subscription.updated"):
+        metadata = obj.get("metadata", {}) or {}
+        owner_type = metadata.get("owner_type")
+        owner_id = metadata.get("owner_id")
+        subscription_id = obj.get("subscription") or obj.get("id")
+        customer_id = obj.get("customer")
+
+        ba = None
+        if BillingModel:
+            # Try metadata mapping first
+            if owner_type and owner_id:
+                try:
+                    target_owner = None
+                    if '.' in owner_type:
+                        owner_app_label, owner_model = owner_type.split('.', 1)
+                        owner_cls = django_apps.get_model(owner_app_label, owner_model)
+                        target_owner = owner_cls.objects.filter(pk=owner_id).first()
+                    else:
+                        owner_cls = None
+                        for app_config in django_apps.get_app_configs():
+                            try:
+                                owner_cls = django_apps.get_model(app_config.label, owner_type)
+                                break
+                            except Exception:
+                                continue
+                        if owner_cls:
+                            target_owner = owner_cls.objects.filter(pk=owner_id).first()
+
+                    # If BillingModel uses Generic relation, find by content_type/object_id
+                    if hasattr(BillingModel, 'content_type') and target_owner:
+                        ct = ContentType.objects.get_for_model(target_owner.__class__)
+                        ba = BillingModel.objects.filter(content_type=ct, object_id=target_owner.pk).first()
+                    else:
+                        # Try common FK names referencing owner
+                        for field_name in ('owner', 'user', 'organization', 'team'):
+                            try:
+                                filter_kwargs = {f"{field_name}__pk": owner_id}
+                                ba = BillingModel.objects.filter(**filter_kwargs).first()
+                                if ba:
+                                    break
+                            except Exception:
+                                continue
+                except Exception:
+                    ba = None
+
+            # fallback: try by stripe customer id
+            if not ba and customer_id:
+                try:
+                    ba = BillingModel.objects.filter(stripe_customer_id=customer_id).first()
+                except Exception:
+                    ba = None
+
+        # If a billing-account instance is found and subscription id is present, persist it.
+        if ba and subscription_id:
+            try:
+                ba.stripe_subscription_id = subscription_id
+                ba.save(update_fields=["stripe_subscription_id"])
+            except Exception:
+                pass
+
+    return HttpResponse(status=200)

--- a/drf_stripe/stripe_webhooks/customer_subscription.py
+++ b/drf_stripe/stripe_webhooks/customer_subscription.py
@@ -1,4 +1,5 @@
 from drf_stripe.models import Subscription, SubscriptionItem, StripeUser
+from drf_stripe.stripe_api.customers import get_billing_model, find_billing_account, update_billing_account_subscription
 from drf_stripe.stripe_models.event import StripeSubscriptionEventData
 
 
@@ -16,19 +17,31 @@ def _handle_customer_subscription_event_data(data: StripeSubscriptionEventData):
 
     stripe_user = StripeUser.objects.get(customer_id=customer)
 
+    subscription_defaults = {
+        "stripe_user": stripe_user,
+        "period_start": period_start,
+        "period_end": period_end,
+        "cancel_at": cancel_at,
+        "cancel_at_period_end": cancel_at_period_end,
+        "ended_at": ended_at,
+        "status": status,
+        "trial_end": trial_end,
+        "trial_start": trial_start
+    }
+
+    # Link to billing account if configured
+    billing_model = get_billing_model()
+    if billing_model:
+        user = stripe_user.user if stripe_user else None
+        billing_account = find_billing_account(billing_model, customer_id=customer, user=user)
+        subscription_defaults = update_billing_account_subscription(
+            billing_model, billing_account, customer, subscription_id, subscription_defaults
+        )
+
     subscription, created = Subscription.objects.update_or_create(
         subscription_id=subscription_id,
-        defaults={
-            "stripe_user": stripe_user,
-            "period_start": period_start,
-            "period_end": period_end,
-            "cancel_at": cancel_at,
-            "cancel_at_period_end": cancel_at_period_end,
-            "ended_at": ended_at,
-            "status": status,
-            "trial_end": trial_end,
-            "trial_start": trial_start
-        })
+        defaults=subscription_defaults
+    )
 
     subscription.items.all().delete()
     _create_subscription_items(data)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django>=3.2
 djangorestframework>=3.10
 pydantic>=1.8, < 2.0
-stripe>=2.63
+stripe==12.5.1
 tox==3.26
 wheel>=0.37

--- a/tests/api/test_billing_account_integration.py
+++ b/tests/api/test_billing_account_integration.py
@@ -1,0 +1,147 @@
+"""Tests for billing account integration with pull_stripe command."""
+from unittest.mock import patch
+
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import TestCase, override_settings
+
+from drf_stripe.models import Subscription, StripeUser
+from drf_stripe.settings import drf_stripe_settings
+from drf_stripe.stripe_api.customers import stripe_api_update_customers
+from drf_stripe.stripe_api.subscriptions import stripe_api_update_subscriptions
+from tests.base import BaseTest
+from tests.models import CustomBilling
+
+
+class TestBillingAccountIntegration(BaseTest):
+    """Test that pull_stripe updates billing account fields correctly."""
+
+    def setUp(self) -> None:
+        self.setup_product_prices()
+        # Create a user and a custom billing account with that user as manager
+        self.user = get_user_model().objects.create(
+            username="tester",
+            email="tester1@example.com",
+            password="12345"
+        )
+        self.custom_billing = CustomBilling.objects.create(
+            name="Test CustomBilling",
+            manager_user=self.user
+        )
+        # Create StripeUser for the test user
+        self.stripe_user = StripeUser.objects.create(
+            user_id=self.user.id,
+            customer_id="cus_tester"
+        )
+
+    def get_billing_settings(self):
+        """Return DRF_STRIPE settings with BILLING_ACCOUNT_MODEL configured."""
+        settings_copy = dict(drf_stripe_settings.user_settings)
+        settings_copy['BILLING_ACCOUNT_MODEL'] = 'tests.CustomBilling'
+        return settings_copy
+
+    def test_update_subscriptions_links_to_billing_account_by_manager_user(self):
+        """
+        Test that stripe_api_update_subscriptions links subscription to billing account
+        when BILLING_ACCOUNT_MODEL is configured and custom billing has manager_user.
+        """
+        with override_settings(DRF_STRIPE=self.get_billing_settings()):
+            drf_stripe_settings.reload()
+
+            response = self._load_test_data("v1/api_subscription_list.json")
+            # Only use the first subscription (for cus_tester)
+            response['data'] = [response['data'][0]]
+
+            stripe_api_update_subscriptions(test_data=response)
+
+            # Check that subscription was created and linked to billing account
+            subscription = Subscription.objects.get(subscription_id="sub_0001")
+            self.assertEqual(subscription.stripe_user.customer_id, "cus_tester")
+
+            # Check that billing account content type and object id are set
+            custom_billing_ct = ContentType.objects.get_for_model(CustomBilling)
+            self.assertEqual(subscription.billing_account_content_type, custom_billing_ct)
+            self.assertEqual(subscription.billing_account_object_id, self.custom_billing.pk)
+
+            # Check that billing account fields are updated
+            self.custom_billing.refresh_from_db()
+            self.assertEqual(self.custom_billing.stripe_customer_id, "cus_tester")
+            self.assertEqual(self.custom_billing.stripe_subscription_id, "sub_0001")
+
+            drf_stripe_settings.reload()
+
+    def test_update_subscriptions_links_by_stripe_customer_id(self):
+        """
+        Test that stripe_api_update_subscriptions finds billing account by stripe_customer_id
+        when the billing account already has it set.
+        """
+        # Set the stripe_customer_id on the custom billing first
+        self.custom_billing.stripe_customer_id = "cus_tester"
+        self.custom_billing.save()
+
+        with override_settings(DRF_STRIPE=self.get_billing_settings()):
+            drf_stripe_settings.reload()
+
+            response = self._load_test_data("v1/api_subscription_list.json")
+            response['data'] = [response['data'][0]]
+
+            stripe_api_update_subscriptions(test_data=response)
+
+            # Check that subscription was linked to billing account
+            subscription = Subscription.objects.get(subscription_id="sub_0001")
+            custom_billing_ct = ContentType.objects.get_for_model(CustomBilling)
+            self.assertEqual(subscription.billing_account_content_type, custom_billing_ct)
+            self.assertEqual(subscription.billing_account_object_id, self.custom_billing.pk)
+
+            # Check that stripe_subscription_id is updated
+            self.custom_billing.refresh_from_db()
+            self.assertEqual(self.custom_billing.stripe_subscription_id, "sub_0001")
+
+            drf_stripe_settings.reload()
+
+    def test_update_customers_updates_billing_account_stripe_customer_id(self):
+        """
+        Test that stripe_api_update_customers updates the billing account's stripe_customer_id
+        when BILLING_ACCOUNT_MODEL is configured.
+        """
+        # Reset the stripe_customer_id on custom billing
+        self.custom_billing.stripe_customer_id = None
+        self.custom_billing.save()
+
+        with override_settings(DRF_STRIPE=self.get_billing_settings()):
+            drf_stripe_settings.reload()
+
+            response = self._load_test_data("v1/api_customer_list_2_items.json")
+            # Only use the first customer (tester1@example.com)
+            response['data'] = [response['data'][0]]
+
+            stripe_api_update_customers(test_data=response)
+
+            # Check that billing account stripe_customer_id is updated
+            self.custom_billing.refresh_from_db()
+            self.assertEqual(self.custom_billing.stripe_customer_id, "cus_tester")
+
+            drf_stripe_settings.reload()
+
+    def test_update_subscriptions_without_billing_model_works_as_before(self):
+        """
+        Test that stripe_api_update_subscriptions works as before when
+        BILLING_ACCOUNT_MODEL is not configured.
+        """
+        response = self._load_test_data("v1/api_subscription_list.json")
+        response['data'] = [response['data'][0]]
+
+        stripe_api_update_subscriptions(test_data=response)
+
+        # Check that subscription was created
+        subscription = Subscription.objects.get(subscription_id="sub_0001")
+        self.assertEqual(subscription.stripe_user.customer_id, "cus_tester")
+
+        # Check that billing account fields are NOT set (legacy behavior)
+        self.assertIsNone(subscription.billing_account_content_type)
+        self.assertIsNone(subscription.billing_account_object_id)
+
+        # CustomBilling should not be updated
+        self.custom_billing.refresh_from_db()
+        self.assertIsNone(self.custom_billing.stripe_customer_id)
+        self.assertIsNone(self.custom_billing.stripe_subscription_id)

--- a/tests/api/test_customer_portal_duplicate_key.py
+++ b/tests/api/test_customer_portal_duplicate_key.py
@@ -1,0 +1,67 @@
+from unittest.mock import patch, MagicMock
+from drf_stripe.models import get_drf_stripe_user_model as get_user_model
+from drf_stripe.models import StripeUser
+from drf_stripe.stripe_api.customers import get_or_create_stripe_user
+from ..base import BaseTest
+
+
+class TestCustomerPortalDuplicateKey(BaseTest):
+    """Test for duplicate key issue when accessing customer portal with multiple subscriptions."""
+
+    @patch('drf_stripe.stripe_api.customers._stripe_api_get_or_create_customer_from_email')
+    def test_get_or_create_stripe_user_multiple_calls(self, mock_stripe_customer):
+        """
+        Test that calling get_or_create_stripe_user multiple times for the same user
+        does not cause a duplicate key error.
+        
+        This simulates the scenario where a user has multiple subscriptions and
+        accesses the customer portal, which should work without errors.
+        """
+        # Mock the Stripe API response
+        mock_customer = MagicMock()
+        mock_customer.id = "cus_test123"
+        mock_stripe_customer.return_value = mock_customer
+        
+        # Create a test user
+        user = get_user_model().objects.create(username="test_user", email="test@example.com")
+        
+        # First call to get_or_create_stripe_user (simulating first subscription)
+        stripe_user1 = get_or_create_stripe_user(user_id=user.id)
+        self.assertIsNotNone(stripe_user1)
+        self.assertIsNotNone(stripe_user1.customer_id)
+        
+        # Store the customer_id from first call
+        first_customer_id = stripe_user1.customer_id
+        
+        # Second call to get_or_create_stripe_user (simulating second subscription or customer portal access)
+        # This should NOT fail with a duplicate key error
+        stripe_user2 = get_or_create_stripe_user(user_id=user.id)
+        self.assertIsNotNone(stripe_user2)
+        self.assertEqual(stripe_user2.customer_id, first_customer_id)
+        
+        # Verify that both calls return the same StripeUser instance
+        self.assertEqual(stripe_user1.user_id, stripe_user2.user_id)
+        
+        # Verify there's only one StripeUser for this user
+        stripe_user_count = StripeUser.objects.filter(user_id=user.id).count()
+        self.assertEqual(stripe_user_count, 1)
+
+    def test_get_or_create_stripe_user_with_existing_stripe_user(self):
+        """
+        Test that get_or_create_stripe_user works correctly when a StripeUser
+        already exists for the user.
+        """
+        # Create a test user and StripeUser directly
+        user = get_user_model().objects.create(username="existing_user", email="existing@example.com")
+        existing_stripe_user = StripeUser.objects.create(user_id=user.id, customer_id="cus_existing123")
+        
+        # Call get_or_create_stripe_user
+        stripe_user = get_or_create_stripe_user(user_id=user.id)
+        
+        # Should return the existing StripeUser
+        self.assertEqual(stripe_user.user_id, existing_stripe_user.user_id)
+        self.assertEqual(stripe_user.customer_id, existing_stripe_user.customer_id)
+        
+        # Verify there's still only one StripeUser
+        stripe_user_count = StripeUser.objects.filter(user_id=user.id).count()
+        self.assertEqual(stripe_user_count, 1)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,0 +1,15 @@
+"""Test models for billing account integration tests."""
+from django.db import models
+from django.contrib.auth import get_user_model
+from drf_stripe.models import AbstractBillingAccount
+
+
+class CustomBilling(AbstractBillingAccount):
+    """Test custom billing model that extends AbstractBillingAccount."""
+    name = models.CharField(max_length=255)
+
+    class Meta:
+        app_label = 'tests'
+
+    def __str__(self):
+        return self.name

--- a/tests/test_billing_account_seats.py
+++ b/tests/test_billing_account_seats.py
@@ -1,0 +1,45 @@
+"""
+Test that the DEFAULT_SUBSCRIPTION_QUANTITY setting works correctly
+and that custom seats fields on billing accounts are respected.
+"""
+from django.test import TestCase, override_settings
+from drf_stripe.settings import drf_stripe_settings
+
+
+class TestBillingAccountSeats(TestCase):
+    """Test seats/quantity behavior with new DEFAULT_SUBSCRIPTION_QUANTITY setting."""
+
+    def test_default_subscription_quantity_setting_exists(self):
+        """Verify the DEFAULT_SUBSCRIPTION_QUANTITY setting is accessible."""
+        self.assertEqual(drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY, 1)
+
+    @override_settings(DRF_STRIPE={"DEFAULT_SUBSCRIPTION_QUANTITY": 5})
+    def test_default_subscription_quantity_can_be_overridden(self):
+        """Verify the DEFAULT_SUBSCRIPTION_QUANTITY setting can be overridden."""
+        # Need to reload settings after override
+        drf_stripe_settings.reload()
+        self.assertEqual(drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY, 5)
+        # Reload again to restore default
+        drf_stripe_settings.reload()
+
+    def test_getattr_fallback_to_setting(self):
+        """Test that getattr uses the setting as fallback when seats doesn't exist."""
+        
+        class MockBillingAccountWithoutSeats:
+            """Mock billing account without seats field."""
+            pass
+        
+        instance = MockBillingAccountWithoutSeats()
+        quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
+        self.assertEqual(quantity, 1)
+
+    def test_getattr_uses_custom_seats_when_present(self):
+        """Test that getattr uses custom seats field when it exists."""
+        
+        class MockBillingAccountWithSeats:
+            """Mock billing account with seats field."""
+            seats = 10
+        
+        instance = MockBillingAccountWithSeats()
+        quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
+        self.assertEqual(quantity, 10)

--- a/tests/test_billing_account_seats.py
+++ b/tests/test_billing_account_seats.py
@@ -3,7 +3,6 @@ Test that the DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting works correctly for subs
 """
 from django.test import TestCase, override_settings
 from drf_stripe.settings import drf_stripe_settings
-from drf_stripe.models import AbstractBillingAccount
 
 
 class TestDefaultMaxSubscriptionQuantity(TestCase):
@@ -21,18 +20,3 @@ class TestDefaultMaxSubscriptionQuantity(TestCase):
         self.assertEqual(drf_stripe_settings.DEFAULT_MAX_SUBSCRIPTION_QUANTITY, 5)
         # Reload again to restore default
         drf_stripe_settings.reload()
-
-
-class TestAbstractBillingAccountFields(TestCase):
-    """Test that AbstractBillingAccount has correct fields after refactoring."""
-    
-    def test_abstract_billing_account_has_required_fields(self):
-        """Verify that AbstractBillingAccount has the required fields."""
-        fields = [f.name for f in AbstractBillingAccount._meta.get_fields()]
-        self.assertIn('stripe_customer_id', fields)
-        self.assertIn('stripe_subscription_id', fields)
-        self.assertIn('manager_user', fields)
-    
-    def test_abstract_billing_account_is_abstract(self):
-        """Verify that AbstractBillingAccount is an abstract model."""
-        self.assertTrue(AbstractBillingAccount._meta.abstract)

--- a/tests/test_billing_account_seats.py
+++ b/tests/test_billing_account_seats.py
@@ -1,5 +1,5 @@
 """
-Test that the DEFAULT_SUBSCRIPTION_QUANTITY setting works correctly.
+Test that the DEFAULT_SUBSCRIPTION_QUANTITY setting works correctly for subscription quantities.
 """
 from django.test import TestCase, override_settings
 from drf_stripe.settings import drf_stripe_settings
@@ -7,7 +7,7 @@ from drf_stripe.models import AbstractBillingAccount, get_drf_stripe_user_model
 
 
 class TestBillingAccountSeats(TestCase):
-    """Test seats/quantity behavior with new DEFAULT_SUBSCRIPTION_QUANTITY setting."""
+    """Test DEFAULT_SUBSCRIPTION_QUANTITY setting behavior for subscription quantities."""
 
     def test_default_subscription_quantity_setting_exists(self):
         """Verify the DEFAULT_SUBSCRIPTION_QUANTITY setting is accessible."""

--- a/tests/test_billing_account_seats.py
+++ b/tests/test_billing_account_seats.py
@@ -3,11 +3,11 @@ Test that the DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting works correctly for subs
 """
 from django.test import TestCase, override_settings
 from drf_stripe.settings import drf_stripe_settings
-from drf_stripe.models import AbstractBillingAccount, get_drf_stripe_user_model
+from drf_stripe.models import AbstractBillingAccount
 
 
-class TestBillingAccountSeats(TestCase):
-    """Test DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting behavior for subscription quantities."""
+class TestDefaultMaxSubscriptionQuantity(TestCase):
+    """Test DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting behavior."""
 
     def test_default_subscription_quantity_setting_exists(self):
         """Verify the DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting is accessible."""
@@ -22,25 +22,9 @@ class TestBillingAccountSeats(TestCase):
         # Reload again to restore default
         drf_stripe_settings.reload()
 
-    def test_getattr_fallback_to_setting(self):
-        """Test that getattr uses the setting as fallback when seats doesn't exist."""
-        
-        class MockBillingAccountWithoutSeats:
-            """Mock billing account without seats field."""
-            pass
-        
-        instance = MockBillingAccountWithoutSeats()
-        quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_MAX_SUBSCRIPTION_QUANTITY)
-        self.assertEqual(quantity, 1)
-
 
 class TestAbstractBillingAccountFields(TestCase):
     """Test that AbstractBillingAccount has correct fields after refactoring."""
-
-    def test_abstract_billing_account_does_not_have_seats_field(self):
-        """Verify that seats field is not in AbstractBillingAccount."""
-        fields = [f.name for f in AbstractBillingAccount._meta.get_fields()]
-        self.assertNotIn('seats', fields)
     
     def test_abstract_billing_account_has_required_fields(self):
         """Verify that AbstractBillingAccount has the required fields."""

--- a/tests/test_billing_account_seats.py
+++ b/tests/test_billing_account_seats.py
@@ -1,6 +1,5 @@
 """
-Test that the DEFAULT_SUBSCRIPTION_QUANTITY setting works correctly
-and that custom seats fields on billing accounts are respected.
+Test that the DEFAULT_SUBSCRIPTION_QUANTITY setting works correctly.
 """
 from django.test import TestCase, override_settings
 from drf_stripe.settings import drf_stripe_settings
@@ -33,69 +32,6 @@ class TestBillingAccountSeats(TestCase):
         instance = MockBillingAccountWithoutSeats()
         quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
         self.assertEqual(quantity, 1)
-
-    def test_getattr_uses_custom_seats_when_present(self):
-        """Test that getattr uses custom seats field when it exists."""
-        
-        class MockBillingAccountWithSeats:
-            """Mock billing account with seats field."""
-            seats = 10
-        
-        instance = MockBillingAccountWithSeats()
-        quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
-        self.assertEqual(quantity, 10)
-
-
-class TestCheckoutSerializerWithBillingAccount(TestCase):
-    """Test CheckoutRequestSerializer uses DEFAULT_SUBSCRIPTION_QUANTITY correctly."""
-
-    def setUp(self):
-        """Set up test data."""
-        # Create a test user
-        User = get_drf_stripe_user_model()
-        self.user = User.objects.create_user(username='testuser', email='test@example.com')
-        
-        # Define reusable mock classes
-        class MockBillingAccountBase:
-            """Base mock billing account."""
-            pk = 1
-            stripe_customer_id = None
-            
-            def get_or_create_stripe_customer(self, stripe_module, **kwargs):
-                return "cus_test123"
-            
-            def can_manage_billing(self, user):
-                return True
-        
-        self.MockBillingAccountBase = MockBillingAccountBase
-
-    def test_checkout_uses_custom_seats_when_present(self):
-        """Test that checkout uses custom seats field when billing account has it."""
-        # Create a mock billing account WITH seats field
-        class MockBillingAccountWithSeats(self.MockBillingAccountBase):
-            seats = 7  # Custom seats value
-        
-        billing_account = MockBillingAccountWithSeats()
-        
-        # Verify that getattr picks up the custom seats value
-        quantity = getattr(billing_account, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
-        self.assertEqual(quantity, 7)
-
-    @override_settings(DRF_STRIPE={"DEFAULT_SUBSCRIPTION_QUANTITY": 5})
-    def test_default_subscription_quantity_used_as_fallback(self):
-        """Test that DEFAULT_SUBSCRIPTION_QUANTITY is used when billing account has no seats."""
-        # Reload settings to pick up override
-        drf_stripe_settings.reload()
-        
-        # Use base mock without seats field
-        billing_account = self.MockBillingAccountBase()
-        
-        # This is how the serializer gets the quantity
-        quantity = getattr(billing_account, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
-        self.assertEqual(quantity, 5)
-        
-        # Restore settings
-        drf_stripe_settings.reload()
 
 
 class TestAbstractBillingAccountFields(TestCase):

--- a/tests/test_billing_account_seats.py
+++ b/tests/test_billing_account_seats.py
@@ -1,5 +1,5 @@
 """
-Test that the DEFAULT_SUBSCRIPTION_QUANTITY setting works correctly for subscription quantities.
+Test that the DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting works correctly for subscription quantities.
 """
 from django.test import TestCase, override_settings
 from drf_stripe.settings import drf_stripe_settings
@@ -7,18 +7,18 @@ from drf_stripe.models import AbstractBillingAccount, get_drf_stripe_user_model
 
 
 class TestBillingAccountSeats(TestCase):
-    """Test DEFAULT_SUBSCRIPTION_QUANTITY setting behavior for subscription quantities."""
+    """Test DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting behavior for subscription quantities."""
 
     def test_default_subscription_quantity_setting_exists(self):
-        """Verify the DEFAULT_SUBSCRIPTION_QUANTITY setting is accessible."""
-        self.assertEqual(drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY, 1)
+        """Verify the DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting is accessible."""
+        self.assertEqual(drf_stripe_settings.DEFAULT_MAX_SUBSCRIPTION_QUANTITY, 1)
 
-    @override_settings(DRF_STRIPE={"DEFAULT_SUBSCRIPTION_QUANTITY": 5})
+    @override_settings(DRF_STRIPE={"DEFAULT_MAX_SUBSCRIPTION_QUANTITY": 5})
     def test_default_subscription_quantity_can_be_overridden(self):
-        """Verify the DEFAULT_SUBSCRIPTION_QUANTITY setting can be overridden."""
+        """Verify the DEFAULT_MAX_SUBSCRIPTION_QUANTITY setting can be overridden."""
         # Need to reload settings after override
         drf_stripe_settings.reload()
-        self.assertEqual(drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY, 5)
+        self.assertEqual(drf_stripe_settings.DEFAULT_MAX_SUBSCRIPTION_QUANTITY, 5)
         # Reload again to restore default
         drf_stripe_settings.reload()
 
@@ -30,7 +30,7 @@ class TestBillingAccountSeats(TestCase):
             pass
         
         instance = MockBillingAccountWithoutSeats()
-        quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_SUBSCRIPTION_QUANTITY)
+        quantity = getattr(instance, "seats", drf_stripe_settings.DEFAULT_MAX_SUBSCRIPTION_QUANTITY)
         self.assertEqual(quantity, 1)
 
 

--- a/tests/test_customer_portal_settings.py
+++ b/tests/test_customer_portal_settings.py
@@ -1,0 +1,63 @@
+from unittest.mock import patch, MagicMock
+from django.test import override_settings
+from drf_stripe.models import get_drf_stripe_user_model as get_user_model
+from drf_stripe.models import StripeUser
+from drf_stripe.stripe_api.customer_portal import stripe_api_create_billing_portal_session
+from drf_stripe.settings import drf_stripe_settings
+from .base import BaseTest
+
+
+class TestCustomerPortalSettings(BaseTest):
+    """Test for customer portal return URL configuration."""
+
+    @patch('drf_stripe.stripe_api.customer_portal.stripe.billing_portal.Session.create')
+    def test_default_customer_portal_return_url(self, mock_session_create):
+        """Test that the default customer portal return URL is used."""
+        # Mock the Stripe API response
+        mock_session = MagicMock()
+        mock_session.url = "https://billing.stripe.com/session/test123"
+        mock_session_create.return_value = mock_session
+        
+        # Create a test user and stripe user
+        user = get_user_model().objects.create(username="test_user", email="test@example.com")
+        StripeUser.objects.create(user_id=user.id, customer_id="cus_test123")
+        
+        # Call the function
+        session = stripe_api_create_billing_portal_session(user.id)
+        
+        # Verify the session was created with the correct return URL
+        mock_session_create.assert_called_once()
+        call_kwargs = mock_session_create.call_args[1]
+        self.assertIn('return_url', call_kwargs)
+        # Default FRONT_END_BASE_URL is http://localhost:3000
+        # Default CUSTOMER_PORTAL_RETURN_URL_PATH is manage-subscription
+        self.assertEqual(call_kwargs['return_url'], 'http://localhost:3000/manage-subscription/')
+
+    @patch('drf_stripe.stripe_api.customer_portal.stripe.billing_portal.Session.create')
+    def test_custom_customer_portal_return_url(self, mock_session_create):
+        """Test that a custom customer portal return URL can be configured."""
+        # Mock the Stripe API response
+        mock_session = MagicMock()
+        mock_session.url = "https://billing.stripe.com/session/test123"
+        mock_session_create.return_value = mock_session
+        
+        # Create a test user and stripe user
+        user = get_user_model().objects.create(username="test_user2", email="test2@example.com")
+        StripeUser.objects.create(user_id=user.id, customer_id="cus_test456")
+        
+        # Override the setting to use a custom return URL path
+        with override_settings(DRF_STRIPE={
+            'FRONT_END_BASE_URL': 'https://example.com',
+            'CUSTOMER_PORTAL_RETURN_URL_PATH': 'billing/portal',
+        }):
+            # Reload settings to pick up the override
+            drf_stripe_settings.reload()
+            
+            # Call the function
+            session = stripe_api_create_billing_portal_session(user.id)
+            
+            # Verify the session was created with the custom return URL
+            mock_session_create.assert_called_once()
+            call_kwargs = mock_session_create.call_args[1]
+            self.assertIn('return_url', call_kwargs)
+            self.assertEqual(call_kwargs['return_url'], 'https://example.com/billing/portal/')

--- a/tests/webhook/test_billing_account_webhook.py
+++ b/tests/webhook/test_billing_account_webhook.py
@@ -1,0 +1,85 @@
+"""Tests for webhook billing account integration."""
+from django.contrib.auth import get_user_model
+from django.contrib.contenttypes.models import ContentType
+from django.test import override_settings
+
+from drf_stripe.models import Subscription, SubscriptionItem, StripeUser
+from drf_stripe.settings import drf_stripe_settings
+from drf_stripe.stripe_webhooks.handler import handle_webhook_event
+from tests.base import BaseTest
+from tests.models import CustomBilling
+
+
+class TestWebhookBillingAccountIntegration(BaseTest):
+    """Test that webhook handlers integrate with billing account correctly."""
+
+    def setUp(self) -> None:
+        self.setup_product_prices()
+        # Create a user and a custom billing account with that user as manager
+        self.user = get_user_model().objects.create(
+            username="tester",
+            email="tester1@example.com",
+            password="12345"
+        )
+        self.custom_billing = CustomBilling.objects.create(
+            name="Test CustomBilling",
+            manager_user=self.user
+        )
+        # Create StripeUser for the test user
+        self.stripe_user = StripeUser.objects.create(
+            user_id=self.user.id,
+            customer_id="cus_tester"
+        )
+
+    def get_billing_settings(self):
+        """Return DRF_STRIPE settings with BILLING_ACCOUNT_MODEL configured."""
+        settings_copy = dict(drf_stripe_settings.user_settings)
+        settings_copy['BILLING_ACCOUNT_MODEL'] = 'tests.CustomBilling'
+        return settings_copy
+
+    def test_webhook_subscription_created_links_to_billing_account(self):
+        """
+        Test that webhook subscription created event links subscription to billing account
+        when BILLING_ACCOUNT_MODEL is configured.
+        """
+        with override_settings(DRF_STRIPE=self.get_billing_settings()):
+            drf_stripe_settings.reload()
+
+            event = self._load_test_data("2020-08-27/webhook_subscription_created.json")
+            handle_webhook_event(event)
+
+            # Check subscription was created and linked to billing account
+            subscription = Subscription.objects.get(subscription_id="sub_1KHlYHL14ex1CGCiIBo8Xk5p")
+            self.assertEqual(subscription.stripe_user.customer_id, "cus_tester")
+
+            # Check billing account content type and object id are set
+            custom_billing_ct = ContentType.objects.get_for_model(CustomBilling)
+            self.assertEqual(subscription.billing_account_content_type, custom_billing_ct)
+            self.assertEqual(subscription.billing_account_object_id, self.custom_billing.pk)
+
+            # Check billing account fields are updated
+            self.custom_billing.refresh_from_db()
+            self.assertEqual(self.custom_billing.stripe_customer_id, "cus_tester")
+            self.assertEqual(self.custom_billing.stripe_subscription_id, "sub_1KHlYHL14ex1CGCiIBo8Xk5p")
+
+            drf_stripe_settings.reload()
+
+    def test_webhook_subscription_without_billing_model_works_as_before(self):
+        """
+        Test that webhook works as before when BILLING_ACCOUNT_MODEL is not configured.
+        """
+        event = self._load_test_data("2020-08-27/webhook_subscription_created.json")
+        handle_webhook_event(event)
+
+        # Check subscription was created
+        subscription = Subscription.objects.get(subscription_id="sub_1KHlYHL14ex1CGCiIBo8Xk5p")
+        self.assertEqual(subscription.stripe_user.customer_id, "cus_tester")
+
+        # Check billing account fields are NOT set (legacy behavior)
+        self.assertIsNone(subscription.billing_account_content_type)
+        self.assertIsNone(subscription.billing_account_object_id)
+
+        # CustomBilling should not be updated
+        self.custom_billing.refresh_from_db()
+        self.assertIsNone(self.custom_billing.stripe_customer_id)
+        self.assertIsNone(self.custom_billing.stripe_subscription_id)


### PR DESCRIPTION
With the help of GitHub CoPilot I implemented some new stuff (that I already tested and using).

* `CUSTOMER_PORTAL_RETURN_URL_PATH` to customize the URL from the Stripe custom portal to go back to the django instance
* BillingAccount feature, basically in case you need to have a membership associate to multiple users or to a specific model 
  * Includes a `manager_user` that is the one that can pay basically
  * It is based on a settings variable to set the model and a command to migrate the data
  * `AbstractBillingAccount` it is the model to extend in the django app
  * `DEFAULT_MAX_SUBSCRIPTION_QUANTITY` another settings to set the maximum amount of subscription items for the user/billing
* Some bugfixes  
* Tests

Probably is not perfect, it works, but I am still testing to see if there are issues with this integration. I suggest doing a squash merge for the vvarious commits.
